### PR TITLE
Force var function to return a vector

### DIFF
--- a/ComBat.m
+++ b/ComBat.m
@@ -78,7 +78,7 @@ function bayesdata=ComBat(dat, batch, mod , par_prior)
     delta_hat=[];
     for i=1:n_batch
         ind1=batch==batch1(i);
-        delta_hat= cat(1,delta_hat, var(s_data(:, ind1)'));
+        delta_hat= cat(1,delta_hat, var(s_data(:, ind1), 0, 2)');
     end
     gamma_bar = mean(gamma_hat,2);
     t2 = var(gamma_hat');


### PR DESCRIPTION
When data is passed in where a batch only has a single sample corresponding to it, `var(s_data(:, ind1)` returns a scalar, which causes the cat command to fail. By passing in the dimension parameter to the `var` command, it forces `var` to return a vector and prevents this problem. We can then transpose the output of `var` to keep the resulting dimensions the same as they were before.